### PR TITLE
Fix so the generated txids are lexically sortable over time

### DIFF
--- a/ngx_txid_module.c
+++ b/ngx_txid_module.c
@@ -64,12 +64,17 @@ ngx_txid_make(unsigned char *out, const size_t len) {
         return -1;
     }
 
+    // The timestamp is 64 bits, but shorten it to 42 bits. This is enough to
+    // store dates up to 2109-05-15 (4398046511103 milliseconds past epoch).
     const ngx_msec_t msec = ngx_txid_next_tick() << 22;
-    out[0] =  (msec >> 56) & 0xff;
-    out[1] =  (msec >> 48) & 0xff;
-    out[2] =  (msec >> 32) & 0xff;
-    out[3] =  (msec >> 16) & 0xff;
-    out[4] |= (msec >> 8)  & 0xff;  // share the 5th byte with entropy
+    out[0] =  (msec >> (64 - 1 * 8)) & 0xff; // 1st byte - bits 1-8 of time
+    out[1] =  (msec >> (64 - 2 * 8)) & 0xff; // 2nd byte - bits 9-16 of time
+    out[2] =  (msec >> (64 - 3 * 8)) & 0xff; // 3rd byte - bits 17-24 of time
+    out[3] =  (msec >> (64 - 4 * 8)) & 0xff; // 4th byte - bits 25-32 of time
+    out[4] =  (msec >> (64 - 5 * 8)) & 0xff; // 5th byte - bits 32-40 of time
+    out[5] |= (msec >> (64 - 6 * 8)) & 0xff; // 6th byte - bits 41-42 of time
+                                             // the rest of the byte is shared
+                                             // with entropy
 
     return 0;
 }

--- a/t/sortable.t
+++ b/t/sortable.t
@@ -1,0 +1,57 @@
+# vi:filetype=perl
+
+delete $ENV{FAKETIME};
+
+use Test::Nginx::Socket;
+
+repeat_each(50);
+log_level('debug');
+workers(4);
+
+# This test ensures that the generated ids are lexically sortable over time and
+# unique across multiple request.
+#
+# Performing this type of test across multiple requests seems a little tricky
+# to accomplish with Test::Nginx. This approach appends each body seen to a
+# global array after each response comes back. Then after each test, we make
+# sure the array of responses is in sorted order. This relies on the fact that
+# we're making multiple requests via repeat_each(50) above.
+our @all_bodies = ();
+our %uniq_bodies = ();
+add_response_body_check(sub {
+    use Time::HiRes;
+    my ($block, $body, $req_idx, $repeated_req_idx, $dry_run) = @_;
+
+    SKIP: {
+        # Briefly sleep between requests to ensure the initial timestamp portion
+        # of the id will increase..
+        Time::HiRes::sleep(0.1);
+
+        push(@all_bodies, $body);
+        $uniq_bodies{$body}++;
+
+        # Ensure all the response bodies seen so far containing txids are in
+        # sorted order over time.
+        my @expected_bodies_order = sort(@all_bodies);
+        is_deeply(\@all_bodies, \@expected_bodies_order, "txids are sorted (req $repeated_req_idx)" );
+
+        # Ensure that each response body seen containing a txid is unique so far.
+        my $actual_uniq_bodies = scalar(keys(%uniq_bodies));
+        my $expected_uniq_bodies = $repeated_req_idx + 1;
+        is($actual_uniq_bodies, $expected_uniq_bodies, "txids are unique (req $repeated_req_idx)" );
+    }
+});
+
+plan tests => repeat_each() * (4 * blocks());
+run_tests();
+
+__DATA__
+
+=== TEST 1: lexically sortable and unique
+--- config
+    location /random {
+      return 200 "$txid";
+    }
+--- request
+    GET /random
+--- response_body_like: ^[0-9a-v]{20}$

--- a/t/time_format_future.t
+++ b/t/time_format_future.t
@@ -1,0 +1,25 @@
+# vi:filetype=perl
+
+# Use libfaketime to test the txid results in the future. This ensures that the
+# format of the encoded id continues to increase lexically as expected.
+$ENV{FAKETIME} = '@2109-01-13 14:24:48';
+
+use Test::Nginx::Socket;
+
+repeat_each(50);
+log_level('debug');
+workers(4);
+
+plan tests => repeat_each() * (2 * blocks());
+run_tests();
+
+__DATA__
+
+=== TEST 1: format of the encoded timestamp in the future
+--- config
+    location /random {
+      return 200 "$txid";
+    }
+--- request
+    GET /random
+--- response_body_like: ^vthkn[0-9a-v]{15}$

--- a/t/time_format_past.t
+++ b/t/time_format_past.t
@@ -1,0 +1,25 @@
+# vi:filetype=perl
+
+# Use libfaketime to test the txid results in the past. This ensures that the
+# format of the encoded id started at a lower lexical values as expected.
+$ENV{FAKETIME} = '@1990-10-13 14:44:10';
+
+use Test::Nginx::Socket;
+
+repeat_each(50);
+log_level('debug');
+workers(4);
+
+plan tests => repeat_each() * (2 * blocks());
+run_tests();
+
+__DATA__
+
+=== TEST 1: format of the encoded timestamp in the past
+--- config
+    location /random {
+      return 200 "$txid";
+    }
+--- request
+    GET /random
+--- response_body_like: ^4om9q[0-9a-v]{15}$


### PR DESCRIPTION
The description of the project and the README indicate the generated IDs should be lexically sortable in their base32 format. However, based on log files, I was consistently seeing a lot of TXIDs being generated out of order. Here's a quick example that I pulled from a log file where I had both the TXID and the timestamp of the request. I then sorted the results by the TXID. As you can see, TXIDs from across days are intermingled, and within days, the timestamps are in the reverse order:

``` csv
"a8ngh01uerf1r7ig51lg","2014-09-29T04:03:50+00:00"
"a8ngjg6fl9fkdqtppokg","2014-09-28T22:49:15+00:00"
"a8ngs02onb550dei94i0","2014-09-29T04:17:03+00:00"
"a8ngv00nfu7j74gm4khg","2014-09-28T20:55:46+00:00"
"a8ngv07p83gdhd077qd0","2014-09-28T17:52:16+00:00"
```

In this example, the requests are spread over a longer period of time, but on a busier server, I was seeing similar problems for requests within a few seconds of each other (there were concentrations of requests where things were sorted properly, but then randomly requests from other hours or days would pop up).

I believe the issue boiled down to the bitwise shifts going on in this bit code:

```
    const ngx_msec_t msec = ngx_txid_next_tick() << 22;
    out[0] =  (msec >> 56) & 0xff;
    out[1] =  (msec >> 48) & 0xff;
    out[2] =  (msec >> 32) & 0xff;
    out[3] =  (msec >> 16) & 0xff;
    out[4] |= (msec >> 8)  & 0xff;  // share the 5th byte with entropy
```

The problem was that not all of the timestamp was actually being added to the output. It's missing the shifts for `40` and `24`. The last shift for the last 2 bits should have also been for `16` (since the whole thing was right shifted by 22 to begin with, there was nothing on the `8` shift, so it was always random). So basically chunks of the timestamp data were missing from the output, so that would explain why things were a bit funky (but the beginning of the timestamp was present, so that's why things were sortable on the scale of multiple days).

I believe the fix for this is pretty straightforward (just filling in the missing shifts so all the timestamp data is present on the output).

The rest of this pull request is adding tests surrounding this behavior. Testing this with `Test::Nginx` was a little trickier than I had anticipated, so let me know if any of it doesn't make sense. Basically there's three new tests to sanity check all this:
- A test that performs 50 consecutive requests, sleeping 0.1 second in between each request. It then ensures that all the TXIDs generated are sortable (on short time-frame test like this, the previous algorithm was failing to provide sortable TXIDs, so even though it's only over a short time, I think this is a decent test of the main sortable behavior).
- A test that uses [libfaketime](https://github.com/wolfcw/libfaketime) fake nginx into thinking the current time is in the past and then checks to ensure the timestamp portion of the txid is what we would expect. I basically wanted some way to make sure the algorithm was sortable over much longer durations. This might have been easier with a C-level test, but since `Test::Nginx` doesn't support this, I landed on libfaketime to achieve this.
- The same test as above, but for a time in the future. Again, just to ensure that the TXID hash continues to increment lexically as expected.

Let me know if you have any questions. Thanks!
