### PR TITLE
Fix so tests pass on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: c
 env:
   - PERL_CPANM_OPT="--mirror http://cpan.cpantesters.org"
 install:
+  # Install newer version of Valgrind from custom repo so Test::Nginx's
+  # num-callers works: https://github.com/openresty/test-nginx/pull/17
+  - sudo add-apt-repository -y ppa:jtaylor/jtaylor
+  - sudo apt-get update -q
   - sudo apt-get -y install valgrind
 script:
   - make grind


### PR DESCRIPTION
I saw my other pull requests failed on travis, but this appears to be due to a [change](https://github.com/openresty/test-nginx/commit/b54ea7b3c4054eaf720de4885b01d00c91372882) in the newer version of `Test::Nginx` that now gets installed. The issue can be resolved by [upgrading valgrind to 3.8+](https://github.com/openresty/test-nginx/pull/17#issuecomment-51648594). This should make Travis happy again.
