### PR TITLE
Fix file descriptor leak on /dev/urandom each time nginx reloads

### DIFF
--- a/ngx_txid_module.c
+++ b/ngx_txid_module.c
@@ -116,7 +116,7 @@ ngx_txid_get(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data
 }
 
 static ngx_int_t
-ngx_txid_init_module(ngx_cycle_t *cycle) {
+ngx_txid_init_process(ngx_cycle_t *cycle) {
     txid_dev_urandom = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
     if (txid_dev_urandom == -1) {
         ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
@@ -128,6 +128,13 @@ ngx_txid_init_module(ngx_cycle_t *cycle) {
                   "opened /dev/urandom %d for pid %d", txid_dev_urandom, ngx_pid);
 
     return NGX_OK;
+}
+
+static void
+ngx_txid_exit_process(ngx_cycle_t *cycle) {
+    if (txid_dev_urandom && txid_dev_urandom != -1) {
+       close(txid_dev_urandom);
+    }
 }
 
 static ngx_str_t ngx_txid_variable_name = ngx_string("txid");
@@ -172,11 +179,11 @@ ngx_module_t  ngx_txid_module = {
   ngx_txid_module_commands,  /* module directives */
   NGX_HTTP_MODULE,                /* module type */
   NULL,                           /* init master */
-  ngx_txid_init_module,           /* init module */
-  NULL,                           /* init process */
+  NULL,                           /* init module */
+  ngx_txid_init_process,          /* init process */
   NULL,                           /* init thread */
   NULL,                           /* exit thread */
-  NULL,                           /* exit process */
+  ngx_txid_exit_process,          /* exit process */
   NULL,                           /* exit master */
   NGX_MODULE_V1_PADDING
 };


### PR DESCRIPTION
Each time nginx was reloaded (via the HUP signal), it was opening new handles to /dev/urandom for each worker process, but failing to close the old unused ones. So if you had 4 worker processes, after 3 reloads, you'd have 16 total handles to /dev/urandom open with 12 of those being unused. This led to an indefinite leaking of file descriptors on the nginx master process, which could eventually culminate in "too many files open" errors killing nginx if you managed to reload nginx enough times to hit your system file descriptor limit.

This shifts the /dev/urandom opening from the init_module into the init_process callback so that each worker process opens its own files.  This then allows us to properly close those file descriptors each time a worker exits on reload via the exit_process callback.  

I'm not exactly sure how to test this within the context of Test::Nginx, but in some manual testing, this does seem to fix the file descriptor leak across repeated reloads.
